### PR TITLE
Graphite Formatter

### DIFF
--- a/lib/passenger_status_check.rb
+++ b/lib/passenger_status_check.rb
@@ -2,6 +2,7 @@ require 'ox'
 require "passenger_status_check/version"
 require 'passenger_status_check/parser'
 require 'passenger_status_check/formatters/check_mk'
+require 'passenger_status_check/formatters/graphite'
 
 module PassengerStatusCheck
 

--- a/lib/passenger_status_check/formatters/graphite.rb
+++ b/lib/passenger_status_check/formatters/graphite.rb
@@ -1,0 +1,64 @@
+require 'passenger_status_check/checks/passenger_check'
+
+module PassengerStatusCheck
+  module Formatters
+    class Graphite
+      attr_reader :parser
+
+      def initialize(parser, thresholds)
+        @parser = parser
+        @thresholds = thresholds
+      end
+
+      def passenger_check
+        @passenger_check ||= PassengerStatusCheck::Checks::PassengerCheck.new(@parser, @thresholds)
+      end
+
+      def output
+        # TODO: define the behavior for graphite export
+        global_queue
+      end
+
+      def now
+        Time.now.to_i
+      end
+
+      def global_queue
+        "passenger.global.queue.count #{global_queue_requests} #{now}"
+      end
+
+      def application_queue
+        "passenger.application.queue.count #{application_queue_requests} #{now}"
+      end
+
+      def passenger_processes
+        "passenger.processes.count #{process_count} #{now}"
+      end
+
+      def global_queue_requests
+        parser.requests_in_top_level_queue
+      end
+
+      def application_queue_requests
+        parser.requests_in_app_queue
+      end
+
+      def process_count
+        parser.process_count
+      end
+
+      def process_data
+        processes = []
+        @parser.processes.each do |process|
+          processes << {
+            pid: process.pid,
+            cpu: process.cpu,
+            memory: process.memory,
+            last_request_time: process.last_request_time
+          }
+        end
+        processes
+      end
+    end
+  end
+end

--- a/spec/lib/passenger_status_check/formatters/graphite_spec.rb
+++ b/spec/lib/passenger_status_check/formatters/graphite_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'passenger_status_check/formatters/graphite'
+
+describe PassengerStatusCheck::Formatters::Graphite do
+
+  describe '#format' do
+    before() do
+      @thresholds = { gqueue: 0, aqueue: 0, pcount: 2..2 }
+      data = File.read('spec/fixtures/pass-status.xml')
+      @parser = PassengerStatusCheck::Parser.new(data)
+      @formatter = PassengerStatusCheck::Formatters::Graphite.new(@parser, @thresholds)
+    end
+
+    describe '#global_queue' do
+      it 'generates output in the expected graphite format' do
+        output = "passenger.global.queue.count 0 #{Time.now.to_i}"
+        expect(@formatter.output).to eq(output)
+      end
+    end
+
+    describe '#application_queue' do
+      it 'generates the application queue for graphite consumption' do
+        output = "passenger.application.queue.count 8 #{Time.now.to_i}"
+        expect(@formatter.application_queue).to eq(output)
+      end
+    end
+
+    describe '#passenger_processes' do
+      it 'generates passenger process count for graphite consumption' do
+        output = "passenger.processes.count 2 #{Time.now.to_i}"
+        expect(@formatter.passenger_processes).to eq(output)
+      end
+    end
+
+    describe '#global_queue_requests' do
+      it 'gets the global queue requests from the parser' do
+        expect(@parser).to receive(:requests_in_top_level_queue)
+        @formatter.global_queue_requests
+      end
+    end
+
+    describe '#application_queue_requests' do
+      it 'gets the application queue requests from the parser' do
+        expect(@parser).to receive(:requests_in_app_queue)
+        @formatter.application_queue_requests
+      end
+    end
+
+    describe '#process_count' do
+      it 'gets the process count from the parser' do
+        expect(@parser).to receive(:process_count)
+        @formatter.process_count
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support to format metrics parsed off the passenger status xml file for graphite consumption

try 

```
cat spec/fixtures/pass-status.xml | passenger_status_check --formatter=graphite
```

or even better:

```
cat spec/fixtures/pass-status.xml | passenger_status_check --formatter=graphite | nc -q0 YOUR_GRAPHITE_IP 2003
```
