### PR TITLE
Include the test suite in gem archives.

### DIFF
--- a/passenger_status_check.gemspec
+++ b/passenger_status_check.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Allowing users to independently verify that the test suite passes for
officially released gem archives is a nice thing.