### PR TITLE
Deployment error - check Passenger status for "resisting deployment" error

### DIFF
--- a/lib/passenger_status_check/checks/passenger_check.rb
+++ b/lib/passenger_status_check/checks/passenger_check.rb
@@ -52,7 +52,7 @@ module PassengerStatusCheck
       end
 
       def resisting_deployment_check
-        if @parser.resisting_deployment.nil?
+        if @parser.resisting_deployment == 0
           OK
         else
           CRITICAL

--- a/lib/passenger_status_check/checks/passenger_check.rb
+++ b/lib/passenger_status_check/checks/passenger_check.rb
@@ -50,6 +50,14 @@ module PassengerStatusCheck
           CRITICAL
         end
       end
+
+      def resisting_deployment_check
+        if @parser.resisting_deployment.nil?
+          OK
+        else
+          CRITICAL
+        end
+      end
     end
   end
 end

--- a/lib/passenger_status_check/formatters/check_mk.rb
+++ b/lib/passenger_status_check/formatters/check_mk.rb
@@ -23,6 +23,7 @@ module PassengerStatusCheck
   module Formatters
     class CheckMk
       attr_reader :parser
+      STATUS_LOOKUP = { 0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN' }.freeze
 
       def initialize(parser, thresholds)
         @parser = parser
@@ -39,6 +40,7 @@ module PassengerStatusCheck
           s << application_queue
           s << passenger_processes
           s << process_data
+          s << resisting_deployment
         end
       end
 
@@ -64,6 +66,11 @@ module PassengerStatusCheck
             "p#{i}_last_request_time=#{process.last_request_time}"
           end.join('|')
         end << " Passenger worker details\n"
+      end
+
+      def resisting_deployment
+        status = passenger_check.resisting_deployment_check
+        "#{status} Passenger_resisting_deployment_status - #{STATUS_LOOKUP[status]}\n"
       end
     end
   end

--- a/lib/passenger_status_check/parser.rb
+++ b/lib/passenger_status_check/parser.rb
@@ -49,5 +49,10 @@ module PassengerStatusCheck
     def requests_in_app_queue
       xml.locate("info/supergroups/supergroup/group/get_wait_list_size/*").first.to_i
     end
+
+    def resisting_deployment
+      nodes = xml.locate("info/supergroups/supergroup/group/resisting_deployment_error/")
+      nodes[0]
+    end
   end
 end

--- a/lib/passenger_status_check/parser.rb
+++ b/lib/passenger_status_check/parser.rb
@@ -51,8 +51,7 @@ module PassengerStatusCheck
     end
 
     def resisting_deployment
-      nodes = xml.locate("info/supergroups/supergroup/group/resisting_deployment_error/")
-      nodes[0]
+      xml.locate("info/supergroups/supergroup/group/resisting_deployment_error/").size
     end
   end
 end

--- a/spec/fixtures/pass-status-error.xml
+++ b/spec/fixtures/pass-status-error.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="iso8859-1"?>
+<info version="3">
+   <passenger_version>5.0.20</passenger_version>
+   <group_count>1</group_count>
+   <process_count>1</process_count>
+   <max>12</max>
+   <capacity_used>1</capacity_used>
+   <get_wait_list_size>0</get_wait_list_size>
+   <supergroups>
+      <supergroup>
+         <name>/var/www/api/current/public (live)</name>
+         <state>READY</state>
+         <get_wait_list_size>0</get_wait_list_size>
+         <capacity_used>1</capacity_used>
+         <group default="true">
+            <name>/var/www/api/current/public (live)</name>
+            <component_name>/var/www/api/current/public (live)</component_name>
+            <app_root>/var/www/api/current</app_root>
+            <app_type>rack</app_type>
+            <environment>live</environment>
+            <uuid>aQPEZh5DIyTeUq6iEBuc</uuid>
+            <enabled_process_count>1</enabled_process_count>
+            <disabling_process_count>0</disabling_process_count>
+            <disabled_process_count>0</disabled_process_count>
+            <capacity_used>1</capacity_used>
+            <get_wait_list_size>14</get_wait_list_size>
+            <disable_wait_list_size>0</disable_wait_list_size>
+            <processes_being_spawned>0</processes_being_spawned>
+            <resisting_deployment_error/>
+            <life_status>ALIVE</life_status>
+            <user>deploy</user>
+            <uid>509</uid>
+            <group>deploy</group>
+            <gid>509</gid>
+            <options>
+               <app_root>/var/www/api/current</app_root>
+               <app_group_name>/var/www/api/current/public (live)</app_group_name>
+               <app_type>rack</app_type>
+               <start_command>/home/deploy/.rvm/wrappers/ruby-2.2.4/ruby	/home/deploy/.rvm/gems/ruby-2.2.4/gems/passenger-enterprise-server-5.0.20/src/helper-scripts/rack-loader.rb</start_command>
+               <startup_file>/var/www/api/current/config.ru</startup_file>
+               <process_title>Passenger RubyApp</process_title>
+               <log_level>3</log_level>
+               <start_timeout>90000</start_timeout>
+               <environment>live</environment>
+               <base_uri>/</base_uri>
+               <spawn_method>smart</spawn_method>
+               <user>deploy</user>
+               <default_user>nobody</default_user>
+               <default_group>nobody</default_group>
+               <integration_mode>nginx</integration_mode>
+               <ruby>/home/deploy/.rvm/wrappers/ruby-2.2.4/ruby</ruby>
+               <python>python</python>
+               <nodejs>node</nodejs>
+               <ust_router_address>unix:/tmp/passenger.6Uxanic/agents.s/ust_router</ust_router_address>
+               <ust_router_username>logging</ust_router_username>
+               <ust_router_password>3MIrWvQ6TywDi4C3bKJ2fzs3</ust_router_password>
+               <debugger>false</debugger>
+               <analytics>false</analytics>
+               <api_key>C3PvY0lcupDSsnEg</api_key>
+               <concurrency_model>process</concurrency_model>
+               <thread_count>1</thread_count>
+               <min_processes>12</min_processes>
+               <max_processes>16</max_processes>
+               <max_preloader_idle_time>300</max_preloader_idle_time>
+               <max_out_of_band_work_instances>1</max_out_of_band_work_instances>
+               <rolling_restart>true</rolling_restart>
+               <ignore_spawn_errors>true</ignore_spawn_errors>
+            </options>
+            <processes>
+               <process>
+                  <pid>20800</pid>
+                  <sticky_session_id>1851464029</sticky_session_id>
+                  <gupid>171a88f-jb8c11OLeb</gupid>
+                  <concurrency>1</concurrency>
+                  <sessions>1</sessions>
+                  <busyness>2147483647</busyness>
+                  <processed>3922125</processed>
+                  <spawner_creation_time>1452180008004983</spawner_creation_time>
+                  <spawn_start_time>1453556127059060</spawn_start_time>
+                  <spawn_end_time>1453556127080035</spawn_end_time>
+                  <last_used>1454007475374106</last_used>
+                  <last_used_desc>0s ago</last_used_desc>
+                  <uptime>5d 5h 22m 28s</uptime>
+                  <code_revision>c7dff8b9ef12087ac530cb4b745b8f16ecbd59f1</code_revision>
+                  <life_status>ALIVE</life_status>
+                  <enabled>ENABLED</enabled>
+                  <has_metrics>true</has_metrics>
+                  <cpu>7</cpu>
+                  <rss>311936</rss>
+                  <pss>311181</pss>
+                  <private_dirty>308240</private_dirty>
+                  <swap>0</swap>
+                  <real_memory>308240</real_memory>
+                  <vmsize>937492</vmsize>
+                  <process_group_id>31324</process_group_id>
+                  <command>Passenger RubyApp: /var/www/api/current/public (live)</command>
+               </process>
+            </processes>
+         </group>
+      </supergroup>
+   </supergroups>
+</info>

--- a/spec/lib/passenger_status_check/formatters/check_mk_spec.rb
+++ b/spec/lib/passenger_status_check/formatters/check_mk_spec.rb
@@ -17,6 +17,7 @@ describe PassengerStatusCheck::Formatters::CheckMk do
 2 Application_queue count=8 Application queue: 8
 0 Passenger_processes count=2 Passenger processes: 2
 0 Passenger_workers p0_cpu=0|p0_memory=264508|p0_last_request_time=1440404826866466|p1_cpu=2|p1_memory=439276|p1_last_request_time=1440424552033587 Passenger worker details
+0 Passenger_resisting_deployment_status - OK
       TXT
       expect(@formatter.output).to eq(output)
     end

--- a/spec/lib/passenger_status_check/parser_spec.rb
+++ b/spec/lib/passenger_status_check/parser_spec.rb
@@ -59,4 +59,10 @@ describe PassengerStatusCheck::Parser do
       end
     end
   end
+
+  describe '#resisting_deployment' do
+    it 'returns the number of resisting-deployment elements' do
+      expect(@parser.resisting_deployment).to eq(0)
+    end
+  end
 end

--- a/spec/passenger_status_check_spec.rb
+++ b/spec/passenger_status_check_spec.rb
@@ -20,6 +20,31 @@ describe PassengerStatusCheck do
 0 Passenger_processes count=2 Passenger processes: 2
 0 Passenger_8439 cpu=0|memory=264508|last_request_time=1440404826866466 Passenger pid 8439 cpu:0 memory:264508 last_request_time:1440404826866466
 0 Passenger_8449 cpu=2|memory=439276|last_request_time=1440424552033587 Passenger pid 8449 cpu:2 memory:439276 last_request_time:1440424552033587
+0 Passenger_resisting_deployment_status - OK
+      TXT
+
+      formatter  = :check_mk
+      thresholds = { gqueue: 0, aqueue: 0, pcount: 2..2 }
+
+      output = PassengerStatusCheck.run(formatter, thresholds, @data)
+
+      expect(output).to match(expected)
+    end
+  end
+  describe 'error .run' do
+    before do
+      file_path = 'spec/fixtures/pass-status-error.xml'
+      @data = File.read(file_path)
+    end
+
+    it 'generates error output compatible with the specified agent' do
+
+      expected = <<-TXT
+0 Global_queue count=0 Global queue: 0
+2 Application_queue count=14 Application queue: 14
+2 Passenger_processes count=1 Passenger processes: 1
+0 Passenger_workers p0_cpu=7|p0_memory=311936|p0_last_request_time=1454007475374106 Passenger worker details
+2 Passenger_resisting_deployment_status - CRITICAL
       TXT
 
       formatter  = :check_mk


### PR DESCRIPTION
Passenger will add a "resisting_deployment_error" element to the XML it produces upon a status check call. A check for existence of this element was add to the passenger_status_check code and the result will be added to the status that is output to Nagios. 

This fix if for:
https://vistahl.atlassian.net/browse/MAE-31785